### PR TITLE
Fix link to catalogue

### DIFF
--- a/fonts/index.html
+++ b/fonts/index.html
@@ -175,7 +175,7 @@
 	<section id="font-notes" class="width">
 		<h1>Notes</h1>
 		<p>This list provides only a preview of the fonts. For usage, please see the <a href="https://github.com/alfredxing/brick/wiki/Usage">wiki</a> page.</p>
-		<p>Also, this list may become incomplete or outdated. For the most up-to-date list, view the <a href="https://github.com/alfredxing/brick/blob/master/cat.json">catalogue source</a>.</p>
+		<p>Also, this list may become incomplete or outdated. For the most up-to-date list, view the <a href="https://github.com/alfredxing/brick/blob/master/index.php#L7-L181">catalogue source</a>.</p>
 	</section>
 	<footer>
 		<p>Copyright &copy; MMXIV <a href="http://alfredxing.com" target="_blank">Alfred Xing</a> &bull; Fonts are copyright of their respective authors.</p>


### PR DESCRIPTION
ideally the catalog page should just be automatically generated from the catalog? Anyways, cat.json was removed in eb85f80159a84125d78bc680f7fef2dba58df58f
