### PR TITLE
Replacing multiple IDs with a single reusable div. Using data-ui-component to keep sections sensible.

### DIFF
--- a/css/main.less
+++ b/css/main.less
@@ -130,10 +130,11 @@ body.index header {
 	}
 }
 
-#hero {
-	text-align: center;
-	padding: 175px 0 200px 0;
-	h1 {
+
+.content {
+	padding: 75px 0;
+	font-size: 14pt;
+		h1 {
 		font-size: 2em;
 		margin: 0;
 		padding: 0;
@@ -165,13 +166,13 @@ body.index header {
 	}
 }
 
-#features, #mission {
-	padding: 150px 0;
-	font-size: 14pt;
+
+.content__header {
+	padding: 175px 0 200px 0;
+	text-align: center;
 }
-#features {
-	padding-bottom: 0;
-}
+
+
 .grid {
 	margin: 0;
 	padding: 0;

--- a/css/main.min.css
+++ b/css/main.min.css
@@ -1,1 +1,39 @@
-body{margin:0;padding:0;border-top:5px solid #ee6650;font:400 12pt "Avenir Next","Helvetica Neue","Open Sans",Arial,sans-serif;-webkit-font-feature-settings:"kern","liga";-ms-font-feature-settings:"kern","liga";font-feature-settings:"kern","liga";text-rendering:optimizeLegibility}a{color:#ee6650;text-decoration:none}a:hover{text-decoration:underline}button,.button{display:inline-block;-webkit-appearance:none;-moz-appearance:none;appearance:none;border:3px solid;background:0 0;padding:5px 10px;border-radius:3px;font:inherit;font-size:.9em;outline:0;cursor:pointer}button.fill,.button.fill{background:#ee6650}hr{border:1px solid #ee6650;margin:2em 0}.width{width:80%;max-width:960px;margin:0 auto}.clearfix:after{clear:both;content:" ";display:block;height:0;visibility:hidden}header{padding:100px 0 15px;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}header:after{clear:both;content:" ";display:block;height:0;visibility:hidden}header a:hover{text-decoration:none;opacity:.75}header div h1{font-size:1.5em;line-height:1em;float:left;margin:0}header div h1 a{color:#222}header nav{float:right}header ul{margin:0;padding:0;list-style-type:none}header li{display:inline-block;text-align:center;margin-left:20px;padding:0 5px}header li a{font-weight:700;line-height:1.5em}header li.active{position:relative}header li.active a{color:#222}header li.active:after{content:" ";position:absolute;background:#222;height:5px;width:100%;left:0;bottom:-20px;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}body.index header{background:#ee6650}body.index header div,body.index header section{width:80%;max-width:960px;margin:0 auto}body.index header h1,body.index header h1 a,body.index header a{color:#FFF}body.index header li.active a{color:#FFF}body.index header li.active:after{background:#FFF}#hero{text-align:center;padding:175px 0 200px}#hero h1{font-size:2em;margin:0;padding:0}#hero .button{padding:10px 20px;border-color:#FFF;color:#FFF;margin-top:25px;font-size:1em;box-shadow:0 1px rgba(34,34,34,.5),0 1px rgba(34,34,34,.5) inset;text-shadow:0 1px rgba(34,34,34,.5)}#hero .button.fill{font-weight:700;background:#FFF;color:#ee6650;box-shadow:0 1px rgba(34,34,34,.5);text-shadow:none}#hero .button:hover{opacity:1;box-shadow:0 2px rgba(34,34,34,.5),0 2px rgba(34,34,34,.5) inset;text-shadow:0 2px rgba(34,34,34,.5)}#hero .button.fill:hover{box-shadow:0 2px rgba(34,34,34,.5);text-shadow:none}#features,#mission{padding:150px 0;font-size:14pt}#features{padding-bottom:0}.grid{margin:0;padding:0;list-style-type:none;text-align:left}.grid:after{clear:both;content:" ";display:block;height:0;visibility:hidden}.grid li{display:block;float:left;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;padding:0 20px}.grid li:first-of-type{padding-left:0}.grid li:last-of-type{padding-right:0}.grid.three li{width:33%}#catalogue{padding:150px 0}#catalogue>h1{margin-bottom:25px}#fonts{margin:0;padding:0;list-style-type:none;width:100%;overflow:hidden}#fonts h1{font-size:1.1em;position:relative;margin-bottom:.5em}#fonts h1:before{content:'\21B3';font-weight:400;position:absolute;right:100%;margin-right:10px}#fonts li{width:100%;margin-bottom:50px}#fonts img{height:100px;width:auto;padding:50px 25px 0;opacity:.5}#fonts img:hover{opacity:.75}#fonts article{width:80%;max-width:960px;margin:0 auto}#font-notes{padding-bottom:150px}footer{background:#ee6650}footer p{width:80%;max-width:960px;margin:0 auto;color:#FFF;padding:50px 0}footer a{color:#FFF;padding-bottom:2px;border-bottom:1px dotted #FFF}footer a:hover{text-decoration:none;border-bottom-style:solid}
+body{margin:0;padding:0;border-top:5px solid #ee6650;font:400 12pt "Avenir Next","Helvetica Neue","Open Sans",Arial,sans-serif;-webkit-font-feature-settings:"kern","liga";-ms-font-feature-settings:"kern","liga";font-feature-settings:"kern","liga";text-rendering:optimizeLegibility}
+a{color:#ee6650;text-decoration:none}
+a:hover{text-decoration:underline}
+button,.button{display:inline-block;-webkit-appearance:none;-moz-appearance:none;appearance:none;border:3px solid;background:none;padding:5px 10px;border-radius:3px;font:inherit;font-size:.9em;outline:none;cursor:pointer}button.fill,.button.fill{background:#ee6650}
+hr{border:1px solid #ee6650;margin:2em 0}
+.width{width:80%;max-width:960px;margin:0 auto}
+.clearfix:after{clear:both;content:" ";display:block;height:0;visibility:hidden}
+header{padding:100px 0 15px 0;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}header:after{clear:both;content:" ";display:block;height:0;visibility:hidden}
+header a:hover{text-decoration:none;opacity:.75}
+header div h1{font-size:1.5em;line-height:1em;float:left;margin:0}header div h1 a{color:#222}
+header nav{float:right}
+header ul{margin:0;padding:0;list-style-type:none}
+header li{display:inline-block;text-align:center;margin-left:20px;padding:0 5px}header li a{font-weight:700;line-height:1.5em}
+header li.active{position:relative}header li.active a{color:#222}
+header li.active:after{content:" ";position:absolute;background:#222;height:5px;width:100%;left:0;bottom:-20px;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}
+body.index header{background:#ee6650}body.index header div,body.index header section{width:80%;max-width:960px;margin:0 auto}
+body.index header h1,body.index header h1 a,body.index header a{color:#fff}
+body.index header li.active a{color:#fff}
+body.index header li.active:after{background:#fff}
+.content{padding:75px 0;font-size:14pt}.content h1{font-size:2em;margin:0;padding:0}
+.content .button{padding:10px 20px;border-color:#fff;color:#fff;margin-top:25px;font-size:1em;box-shadow:0 1px rgba(34,34,34,0.5),0 1px rgba(34,34,34,0.5) inset;text-shadow:0 1px rgba(34,34,34,0.5)}.content .button.fill{font-weight:700;background:#fff;color:#ee6650;box-shadow:0 1px rgba(34,34,34,0.5);text-shadow:none}
+.content .button:hover{opacity:1;box-shadow:0 2px rgba(34,34,34,0.5),0 2px rgba(34,34,34,0.5) inset;text-shadow:0 2px rgba(34,34,34,0.5)}
+.content .button.fill:hover{box-shadow:0 2px rgba(34,34,34,0.5);text-shadow:none}
+.content__header{padding:175px 0 200px 0;text-align:center}
+.grid{margin:0;padding:0;list-style-type:none;text-align:left}.grid:after{clear:both;content:" ";display:block;height:0;visibility:hidden}
+.grid li{display:block;float:left;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;padding:0 20px}
+.grid li:first-of-type{padding-left:0}
+.grid li:last-of-type{padding-right:0}
+.grid.three li{width:33%}
+#catalogue{padding:150px 0}#catalogue>h1{margin-bottom:25px}
+#fonts{margin:0;padding:0;list-style-type:none;width:100%;overflow:hidden}#fonts h1{font-size:1.1em;position:relative;margin-bottom:.5em}#fonts h1:before{content:'\21B3';font-weight:400;position:absolute;right:100%;margin-right:10px}
+#fonts li{width:100%;margin-bottom:50px}
+#fonts img{height:100px;width:auto;padding:50px 25px 0 25px;opacity:.5}
+#fonts img:hover{opacity:.75}
+#fonts article{width:80%;max-width:960px;margin:0 auto}
+#font-notes{padding-bottom:150px}
+footer{background:#ee6650}footer p{width:80%;max-width:960px;margin:0 auto;color:#fff;padding:50px 0}
+footer a{color:#fff;padding-bottom:2px;border-bottom:1px dotted #fff}
+footer a:hover{text-decoration:none;border-bottom-style:solid}

--- a/index.html
+++ b/index.html
@@ -19,13 +19,13 @@
 				</ul>
 			</nav>
 		</div>
-		<section id="hero">
+		<section class="content content__header">
 			<h1>Webfonts that actually look good.</h1>
 			<a href="https://github.com/alfredxing/brick/wiki/Usage" class="button">Get started</a>&nbsp;&nbsp;
 			<a href="./fonts" class="button">Browse fonts</a>
 		</section>
 	</header>
-	<section id="features" class="width">
+	<section class="content width" data-ui-component="features">
 		<h2>Why Brick?</h2>
 		<ul class="grid three">
 			<li>
@@ -42,7 +42,7 @@
 			</li>
 		</ul>
 	</section>
-	<section id="mission" class="width">
+	<section class="content width" data-ui-component="mission">
 		<h2>Mission</h2>
 		<p>
 			In the age of the Internet, we've found ourselves in yet another typographic battle. In an effort to speed up loading times, we've compressed fonts, and along the way, we've lost the majority of the quality of rendered type.


### PR DESCRIPTION
# Front-end code fix
## Replacing 3 IDs with a single div.

I thought it would be a better idea to have one reusable class for the style rules shared among three IDs. Part of #hero was replaced into .content__header and the rest of #hero, #features, and #mission was replaced into the .content object. Generally, IDs aren't reusable and should be used only for hooking JS into a site.
# hero --> .content__header
# hero, #mission, #features --> .content
## How has describing the site's content changed?

The ID names seemed sensible enough. #features had content describing the features, and #mission had the mission statement.  To not lose this sensibility while reading the code, I used the data-ui-component="" attribute. Example, data-ui-component="features". 
## What's next?

There are still changes that can be made with the same mindset.  Styling elements can lead to be hazardous as a site grows. We can change this by making more sensible, abstract, loosely coupled classes and only using IDs for JavaScript hooking.  However, I believe this was a good start. I'd also like to see if we can find a better responsive web design solution for smaller screen sizes.

_Hopefully this makes sense, didn't break anything, and you enjoy these ideas, Cheers!_
