### PR TITLE
Update fonts.yaml

### DIFF
--- a/_data/fonts.yaml
+++ b/_data/fonts.yaml
@@ -1,6 +1,6 @@
 Alegreya:
     class: serif
-    use:
+    use: body
     styles:
         400: "Alegreya"
         400i: "Alegreya Italic"
@@ -54,7 +54,7 @@ Bitter:
         700i: "Bitter Bold Italic"
 Clear Sans:
     class: sans
-    use:
+    use: body
     styles:
         200: "Clear Sans Thin"
         300: "Clear Sans Light"
@@ -76,7 +76,7 @@ Comic Neue:
         700i: "Comic Neue Bold Oblique"
 Crimson:
     class: serif
-    use:
+    use: body
     styles:
         400: "Crimson Roman"
         400i: "Crimson Italic"
@@ -86,13 +86,13 @@ Crimson:
         700i: "Crimson Bold Italic"
 Domine:
     class: serif
-    use:
+    use: body
     styles:
         400: "Domine"
         700: "Domine Bold"
 Droid Serif:
     class: serif
-    use:
+    use: body
     styles:
         400: "Droid Serif"
         400i: "Droid Serif Italic"
@@ -100,13 +100,13 @@ Droid Serif:
         700i: "Droid Serif Bold Italic"
 EB Garamond:
     class: serif
-    use:
+    use: body
     styles:
         400: "EB Garamond 12 Regular"
         400i: "EB Garamond 12 Italic"
 Fira Sans:
     class: sans
-    use:
+    use: body
     styles:
         300: "Fira Sans OT Light"
         300i: "Fira Sans OT Light Italic"
@@ -118,7 +118,7 @@ Fira Sans:
         700i: "Fira Sans OT Bold Italic"
 Gentium Basic:
     class: serif
-    use:
+    use: body
     styles:
         400: "Gentium Basic"
         400i: "Gentium Basic Italic"
@@ -131,7 +131,7 @@ Inconsolata:
         500: "Inconsolata"
 Karla:
     class: sans
-    use:
+    use: body
     styles:
         400: "Karla Regular"
         400i: "Karla Italic"
@@ -139,7 +139,7 @@ Karla:
         700i: "Karla Bold Italic"
 Latin Modern:
     class: serif
-    use:
+    use: display
     styles:
         400: "LMRoman10-Regular"
         400i: "LMRoman10-Italic"
@@ -147,7 +147,7 @@ Latin Modern:
         700i: "LMRoman10-BoldItalic"
 Lato:
     class: sans
-    use:
+    use: body
     styles:
         100: "Lato Hairline"
         100i: "Lato Hairline Italic"
@@ -176,7 +176,7 @@ Libre Baskerville:
         700: "Libre Baskerville Bold"
 Linux Libertine:
     class: serif
-    use:
+    use: body
     styles:
         400: "Linux Libertine O"
         400i: "Linux Libertine O Italic"
@@ -204,7 +204,7 @@ Montserrat:
         700: "Montserrat-Bold"
 Noto Sans:
     class: sans
-    use:
+    use: body
     styles:
         400: "Noto Sans Regular"
         400i: "Noto Sans Italic"
@@ -212,7 +212,7 @@ Noto Sans:
         700i: "Noto Sans Bold Italic"
 Noto Serif:
     class: serif
-    use:
+    use: body
     styles:
         400: "Noto Serif Regular"
         400i: "Noto Serif Italic"
@@ -220,14 +220,14 @@ Noto Serif:
         700i: "Noto Serif Bold Italic"
 Old Standard:
     class: serif
-    use:
+    use: display
     styles:
         400: "Old Standard Regular"
         400i: "Old Standard Italic"
         700: "Old Standard Bold"
 Open Sans:
     class: sans
-    use:
+    use: body
     styles:
         300: "Open Sans Light"
         300i: "Open Sans Light Italic"
@@ -251,7 +251,7 @@ Playfair Display:
         900i: "Playfair Display Black Italic"
 PT Sans:
     class: sans
-    use:
+    use: body
     styles:
         400: "PT Sans"
         400i: "PT Sans Italic"
@@ -259,7 +259,7 @@ PT Sans:
         700i: "PT Sans Bold Italic"
 PT Serif:
     class: serif
-    use:
+    use: body
     styles:
         400: "PT Serif"
         400i: "PT Serif Italic"
@@ -267,7 +267,7 @@ PT Serif:
         700i: "PT Serif Bold Italic"
 Raleway:
     class: sans
-    use:
+    use: body
     styles:
         100: "Raleway Thin"
         100i: "Raleway Thin Italic"
@@ -289,7 +289,7 @@ Raleway:
         900i: "Raleway Heavy Italic"
 Roboto:
     class: sans
-    use:
+    use: body
     styles:
         200: "Roboto Thin"
         200i: "Roboto Thin Italic"
@@ -324,7 +324,7 @@ Source Code Pro:
         900: "Source Code Pro Black"
 Source Sans Pro:
     class: sans
-    use:
+    use: body
     styles:
         200: "Source Sans Pro ExtraLight"
         200i: "Source Sans Pro ExtraLight Italic"


### PR DESCRIPTION
Added uses for a number of fonts. 

Note that many of the fonts labelled 'body' can also be used for headlines, while display fonts do not make for readable body text.
