### PR TITLE
Skip non-existent families and weights

### DIFF
--- a/brick.go
+++ b/brick.go
@@ -59,6 +59,11 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		for _, weight := range weights {
+			// Verify that variant exists, else move on
+			if _, exists := fonts[family][weight]; !exists {
+				continue
+			}
+
 			var uri bytes.Buffer
 
 			// Local font URI

--- a/brick_test.go
+++ b/brick_test.go
@@ -86,6 +86,46 @@ func TestFamilies(t *testing.T) {
 	}
 }
 
+// Tests a request including non-existing variants
+func TestNonexistentVariant(t *testing.T) {
+	res := httptest.NewRecorder()
+
+	req, err := http.NewRequest("GET", "http://brick.im/Open+Sans:400,800", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	handler(res, req)
+	if res.Code != 200 {
+		t.Fail()
+	}
+
+	var expected = formatRule("Open Sans", "normal", "400", "Open Sans Regular", "opensans", "400")
+	if res.Body.String() != expected {
+		t.Fail()
+	}
+}
+
+// Tests a request including non-existing families
+func TestNonexistentFamily(t *testing.T) {
+	res := httptest.NewRecorder()
+
+	req, err := http.NewRequest("GET", "http://brick.im/Foo+Sans:400/Open+Sans:400", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	handler(res, req)
+	if res.Code != 200 {
+		t.Fail()
+	}
+
+	var expected = formatRule("Open Sans", "normal", "400", "Open Sans Regular", "opensans", "400")
+	if res.Body.String() != expected {
+		t.Fail()
+	}
+}
+
 // Tests a request using the force flag (preventing the browser from
 // loading the font from the local computer)
 func TestForce(t *testing.T) {


### PR DESCRIPTION
Skip `@font-face` rules for non-existent families and weights. Spares the server 404 requests for sites requesting these non-existent fonts.
