### PR TITLE
Move to global CDN

### DIFF
--- a/brick.go
+++ b/brick.go
@@ -75,7 +75,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 			}
 
 			// Brick URI
-			uri.WriteString("url(//brick.a.ssl.fastly.net/fonts/")
+			uri.WriteString("url(//brick.global.ssl.fastly.net/fonts/")
 			uri.WriteString(strings.ToLower(strings.Replace(family, " ", "", -1)))
 			uri.WriteString("/")
 			uri.WriteString(weight)


### PR DESCRIPTION
Currently, the fonts are loading just from Fastly's "A" region, which makes this _much_ slower than Google Fonts for a certain hemisphere...
